### PR TITLE
jumpThrough and some bug fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ let checkBallWallsCollision = () => {
   }
 };
 
+// finds the shapes that are colliding when the pen ENTERS the shape (not inside or when "exiting")
 let checkPenShapeCollision = () => {
   let collidingShapes = shapes.filter((shape) => {
     let shapeLeft = shape.x;
@@ -38,16 +39,19 @@ let checkPenShapeCollision = () => {
     let penX = pen.lastCornerX;
     let penY = pen.lastCornerY;
 
-    if (penX === shapeRight || penX === shapeLeft) {
-      if (penY >= shapeTop && penY <= shapeBottom) {
-        //pen.jumpThrough(shape);
-
+    if ((pen.direction === "Left" && penX === shapeRight) || (pen.direction === "Right" && penX === shapeLeft)) {
+      if (penY >= shapeTop && penY <= shapeBottom) {        
+        // var { currentPosition, ...rest } = pen; console.table(rest); console.table(shape) // debugging
+        pen.jumpThrough(shape);
+        // var { currentPosition, ...rest } = pen; console.table(rest); console.table(shape) // debugging
         return true;
       }
     }
-    if (penY === shapeTop || penY === shapeBottom) {
+    if ((pen.direction === "Down" && penY === shapeTop) || (pen.direction === "Up" && penY === shapeBottom)) {
       if (penX >= shapeLeft && penX <= shapeRight) {
-        //pen.jumpThrough(shape);
+        // var { currentPosition, ...rest } = pen; console.table(rest); console.table(shape) // debugging
+        pen.jumpThrough(shape);
+        // var { currentPosition, ...rest } = pen; console.table(rest); console.table(shape) // debugging
 
         return true;
       }

--- a/pen.js
+++ b/pen.js
@@ -73,61 +73,70 @@ class Pen {
     }
   }
 
+  _hasMoved() {
+    // checking if this is a completely new pen (in which case, don't jump)
+    if (
+      pen.lastCornerX >= 800 ||
+      pen.lastCornerX <= 0 ||
+      pen.lastCornerY >= 800 ||
+      pen.lastCornerY <= 0
+    ) {
+      return false;
+    } else {
+      return true
+    }
+  }
+
   jumpThrough(shape) {
-    // if (
-    //   pen.lastCornerX >= 800 ||
-    //   pen.lastCornerX <= 0 ||
-    //   pen.lastCornerY >= 800 ||
-    //   pen.lastCornerY <= 0
-    // ) {
-    //   return;
-    // }
-    //console.table(pen);
+    if (!this._hasMoved()) {
+      return
+    }
+    var { currentPosition, ...rest } = pen; console.table(rest) // debugging
     if (this.turnCounter === null) {
       if (this.direction === "Left") {
-        this.firstCornerX -= shape.width;
+        this.firstCornerX -= shape.width - 5;
         this.secondCornerX = this.firstCornerX;
         this.lastCornerX = this.firstCornerX;
       } else if (this.direction === "Right") {
-        this.firstCornerX += shape.width;
+        this.firstCornerX += shape.width - 5;
         this.secondCornerX = this.firstCornerX;
         this.lastCornerX = this.firstCornerX;
       } else if (this.direction === "Up") {
-        this.firstCornerY -= shape.height;
+        this.firstCornerY -= shape.height - 5;
         this.secondCornerY = this.firstCornerY;
         this.lastCornerY = this.firstCornerY;
       } else if (this.direction === "Down") {
-        this.firstCornerY += shape.height;
+        this.firstCornerY += shape.height - 5;
         this.secondCornerY = this.firstCornerY;
         this.lastCornerY = this.firstCornerY;
       }
     } else if (this.turnCounter === 1) {
       if (this.direction === "Left") {
-        this.secondCornerX -= shape.width;
+        this.secondCornerX -= shape.width - 5;
 
         this.lastCornerX = this.secondCornerX;
       } else if (this.direction === "Right") {
-        this.secondCornerX += shape.width;
+        this.secondCornerX += shape.width - 5;
 
         this.lastCornerX = this.secondCornerX;
       } else if (this.direction === "Up") {
-        this.secondCornerY -= shape.height;
+        this.secondCornerY -= shape.height - 5;
 
         this.lastCornerY = this.secondCornerY;
       } else if (this.direction === "Down") {
-        this.secondCornerY += shape.height;
+        this.secondCornerY += (shape.height - 5);
 
         this.lastCornerY = this.secondCornerY;
       }
     } else if (this.turnCounter === 2) {
       if (this.direction === "Left") {
-        this.lastCornerX -= shape.width;
+        this.lastCornerX -= shape.width - 5;
       } else if (this.direction === "Right") {
-        this.lastCornerX += shape.width;
+        this.lastCornerX += shape.width - 5;
       } else if (this.direction === "Up") {
-        this.lastCornerY -= shape.height;
+        this.lastCornerY -= shape.height - 5;
       } else if (this.direction === "Down") {
-        this.lastCornerY += shape.height;
+        this.lastCornerY += shape.height - 5;
       }
     }
   }
@@ -326,7 +335,7 @@ class Pen {
             x: this.firstCornerX,
             y: this.firstCornerY,
             width: canvas.width - this.firstCornerX,
-            height: this.firstCornerY,
+            height: canvas.height - this.firstCornerY,
           });
         }
       }
@@ -561,7 +570,7 @@ class Pen {
           } else {
             shapes.push(
               {
-                x: this.firstCornerY,
+                x: this.firstCornerX,
                 y: this.firstCornerY,
                 width: canvas.width - this.firstCornerX,
                 height: canvas.height - this.firstCornerY,


### PR DESCRIPTION
-  fixes two bugs in saving shapes
- makes jumpThrough only work for not immediately new pens 
- only considers shape and pen colliding if the pen currently ENTERS the shape (not while exiting the shape on the other side)

Known Issues:
- if two shapes overlap (like in the screenshot) the pen will only jump through the first shape (because collision is only checked for when _entering_ a shape and the second shape never gets entered on the side, the pen immediately jumps to somewhere inside it)..
- I think this is not a huge problem since this situation does not happen very often, can probably ignore for now
![Screen Shot 2021-07-07 at 11 20 17](https://user-images.githubusercontent.com/1608014/124736919-c35fa800-df17-11eb-925b-b934fcf6cdfd.png)

